### PR TITLE
Fix macOS clang build due to missing array include

### DIFF
--- a/src/setting.cpp
+++ b/src/setting.cpp
@@ -2,6 +2,7 @@
  * settings.cpp
  */
 
+#include <array>
 #include <QApplication>
 #include <QTextStream>
 #include <QStandardPaths>


### PR DESCRIPTION
Currently, `master` fails to build on macOS 10.14.4 with the default clang toolkit due to:
```
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang++ -c -pipe -stdlib=libc++ -O2 -std=gnu++11  -arch x86_64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk -mmacosx-version-min=10.12 -Wall -W -fPIC -DDATADIR=\"/opt/share/q5go\" -DDOCDIR=\"/opt/share/doc/q5go\" -DNO_CHECK -DQT_NO_DEBUG -DQT_SVG_LIB -DQT_WIDGETS_LIB -DQT_MULTIMEDIA_LIB -DQT_GUI_LIB -DQT_XML_LIB -DQT_NETWORK_LIB -DQT_SQL_LIB -DQT_CORE_LIB -I../src -I. -I../src -I/usr/local/Cellar/qt/5.12.2/lib/QtSvg.framework/Headers -I/usr/local/Cellar/qt/5.12.2/lib/QtWidgets.framework/Headers -I/usr/local/Cellar/qt/5.12.2/lib/QtMultimedia.framework/Headers -I/usr/local/Cellar/qt/5.12.2/lib/QtGui.framework/Headers -I/usr/local/Cellar/qt/5.12.2/lib/QtXml.framework/Headers -I/usr/local/Cellar/qt/5.12.2/lib/QtNetwork.framework/Headers -I/usr/local/Cellar/qt/5.12.2/lib/QtSql.framework/Headers -I/usr/local/Cellar/qt/5.12.2/lib/QtCore.framework/Headers -Itemp_ -I/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk/System/Library/Frameworks/OpenGL.framework/Headers -I/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk/System/Library/Frameworks/AGL.framework/Headers/ -Itemp_ -I/usr/local/Cellar/qt/5.12.2/mkspecs/macx-clang -F/usr/local/Cellar/qt/5.12.2/lib -o temp_/setting.o ../src/setting.cpp
../src/setting.cpp:489:64: error: implicit instantiation of undefined template 'std::__1::array<const char *, 15>'
static std::array<const char *, NUMBER_OF_AVAILABLE_LANGUAGES> language_codes LANGUAGE_CODES;
                                                               ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/__tuple:223:64: note: template is declared here
template <class _Tp, size_t _Size> struct _LIBCPP_TEMPLATE_VIS array;
                                                               ^
../src/setting.cpp:490:64: error: implicit instantiation of undefined template 'std::__1::array<const char *, 15>'
static std::array<const char *, NUMBER_OF_AVAILABLE_LANGUAGES> available_languages AVAILABLE_LANGUAGES;
                                                               ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/__tuple:223:64: note: template is declared here
template <class _Tp, size_t _Size> struct _LIBCPP_TEMPLATE_VIS array;
                                                               ^
2 errors generated.
make: *** [temp_/setting.o] Error 1
```

Simply importing `<array>` explicitly fixes it.

I'm not sure how _other_ platforms are building without it; I guess GCC must be picking it up transitively in some way that clang doesn't, but I'm fairly sure this isn't harmful to GCC either way.