### PR TITLE
fc29/fc31 compile fix. 

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -62,9 +62,19 @@ AC_PATH_PROG(qtchooser, qtchooser, , $PATH:$QTDIR/bin)
 if test -z "QTCHOOSER" ; then
     AC_MSG_ERROR([Cannot find 'qtchooser'])
 else
-    MOC='qtchooser -run-tool=moc -qt=qt5'
-    UIC='qtchooser -run-tool=uic -qt=qt5'
-    RCC='qtchooser -run-tool=rcc -qt=qt5'
+    QT_LABELS="$(qtchooser -list-versions)"
+    if grep -q "qt5" <<< "$QT_LABELS" ; then
+        QT5_NAME="qt5"
+    elif grep -q "5-64" <<< "$QT_LABELS" ; then
+        QT5_NAME="5-64"
+    elif grep -q "5" <<< "$QT_LABELS" ; then
+        QT5_NAME="5"
+    else
+        AC_MSG_ERROR([Cannot find a version of 'qt5' within 'qtchooser'])
+    fi
+    MOC="qtchooser -run-tool=moc -qt=$QT5_NAME"
+    UIC="qtchooser -run-tool=uic -qt=$QT5_NAME"
+    RCC="qtchooser -run-tool=rcc -qt=$QT5_NAME"
 fi
 
 CXXFLAGS="$CXXFLAGS $QT5_CFLAGS -fPIC"


### PR DESCRIPTION
'qtchooser' uses the names '5-64' and '5' for qt5 in Fedora, and this 'configure.ac' has 'qt5' as the name hard coded.

This changes the 'autoconf' output to adjust accordingly.

After this patch, running 'autoconf; ./configure; make' runs flawlessly on Fedora.

Basically this just looks at the output of $(qtchooser -list-versions) and checks to see if "qt5" is listed, if not, checks "5-64", if not, checks "5", if not, throws an error.

Since you also have "configure" hard packaged with the source, you could also rerun "autoconf" and patch that output "configure" script if you want (I didn't here), as long as it tests correctly on Debian or whatever you are compiling/testing on.  Otherwise, people might need to be informed to run "autoconf" themselves if they are on Fedora.

Notes for people trying to compile who see this note, the packages "qt5", "qt5-devel", and "qtchooser" also need to be installed in Fedora for compilation.