### PR TITLE
Add option to show score as analysis marks

### DIFF
--- a/src/board.cpp
+++ b/src/board.cpp
@@ -1106,22 +1106,37 @@ Board::ram_result Board::render_analysis_marks (svg_builder &svg, double svg_fac
 	}
 	svg.circle_at (cx, cy, svg_factor * 0.45, wr_col, child_mark ? "white" : "black", "1");
 
-	if (analysis_vartype == 0) {
+	if (analysis_vartype == 0) {  // letters
 		QChar c = pv_idx >= 26 ? 'a' + pv_idx - 26 : 'A' + pv_idx;
 		svg.text_at (cx, cy, svg_factor, 0, c,
 			     "black", fi);
-	} else {
+	} else if (analysis_vartype == 1) {  // win rate (relative)
 		double shown_val = wrdiff;
-		if (analysis_vartype == 2) {
-			shown_val = wr;
 
-			if (to_move == wr_swap_col)
-				shown_val = 1 - shown_val;
-		} else if (to_move == wr_swap_col)
+		if (to_move == wr_swap_col)
 			shown_val = -shown_val;
 
 		svg.text_at (cx, cy, svg_factor, 4,
 			     QString::number (shown_val * 100, 'f', 1),
+			     "black", fi);
+	} else if (analysis_vartype == 2) {  // win rate (absolute)
+		double shown_val = wr;
+
+		if (to_move == wr_swap_col)
+			shown_val = 1 - shown_val;
+
+		svg.text_at (cx, cy, svg_factor, 4,
+			     QString::number (shown_val * 100, 'f', 1),
+			     "black", fi);
+	} else {  // score
+		double shown_val = ev.score_mean;
+		int precision = abs(shown_val) < 2 ? 1 : 0;
+
+		if (to_move == white)
+			shown_val = -shown_val;
+
+		svg.text_at (cx, cy, svg_factor, 4,
+			     QString::number (shown_val, 'f', precision),
 			     "black", fi);
 	}
 	return ram_result::hide;

--- a/src/preferences_gui.ui
+++ b/src/preferences_gui.ui
@@ -2553,6 +2553,11 @@ If the picture is not set, or unvalid, a default goban is used by qgo</string>
               <string>Absolute percentage</string>
              </property>
             </item>
+            <item>
+             <property name="text">
+              <string>Score</string>
+             </property>
+            </item>
            </widget>
           </item>
           <item row="1" column="0">
@@ -2917,7 +2922,7 @@ Port address is defined for each go server. It's a fixed number. See Host for pr
            <property name="whatsThis">
             <string>name
 
-Registered users: 
+Registered users:
 use your login name and password provided by the go server operator after registration
 
 New users: depends on server
@@ -2960,7 +2965,7 @@ others:		guest</string>
            <property name="whatsThis">
             <string>password
 
-Registered users: 
+Registered users:
 use your login name and password provided by the go server operator after registration
 
 New users: leave blank!</string>
@@ -3292,7 +3297,7 @@ Allow client to negotiate komi automatic.
 Be careful: it may be annoying if opponent does not want to accept your defaults even if defaults have been sent to opponent before. This may be due to different internal use of negotiation values by clients.</string>
                      </property>
                      <property name="text">
-                      <string>Automatic komi 
+                      <string>Automatic komi
 negotiation</string>
                      </property>
                     </widget>
@@ -3337,7 +3342,7 @@ negotiation</string>
                         <bool>false</bool>
                        </property>
                        <property name="text">
-                        <string>Main 
+                        <string>Main
 time :</string>
                        </property>
                        <property name="alignment">
@@ -3550,7 +3555,7 @@ time:</string>
                         <string>Playing time</string>
                        </property>
                        <property name="text">
-                        <string>Main time 
+                        <string>Main time
 up to :</string>
                        </property>
                        <property name="alignment">
@@ -3788,7 +3793,7 @@ up to :</string>
                         <string>board size</string>
                        </property>
                        <property name="text">
-                        <string>Handicap 
+                        <string>Handicap
 up to :</string>
                        </property>
                        <property name="alignment">
@@ -5142,7 +5147,7 @@ If checked then when a game you played completes, it is automatically saved in t
               <widget class="QLabel" name="label_37">
                <property name="text">
                  <string>Marked directories contain a Kombilo DB, which cannot be used for pattern search.
-Use the "Create DB" to create a q5go database.</string>
+Use the &quot;Create DB&quot; to create a q5go database.</string>
                </property>
               </widget>
              </item>


### PR DESCRIPTION
This change adds the possibility to show the estimated score of each move when showing analysis marks, and an engine that can give them (like katago).

I haven't added translations, and there are some other changes in preferences_gui.ui that my version of designer added, but hopefully those do not matter (for the moment)?