### PR TITLE
Add option to show variations as score difference

### DIFF
--- a/src/board.h
+++ b/src/board.h
@@ -335,7 +335,7 @@ protected:
 
 	virtual bool have_analysis () override;
 	game_state *analysis_primary_move ();
-	game_state *analysis_at (int x, int y, int &, double &);
+	game_state *analysis_at (int x, int y, int &, double &, double &);
 	virtual stone_color cursor_color (int x, int y, stone_color to_move) override;
 	virtual ram_result render_analysis_marks (svg_builder &, double svg_factor, double cx, double cy, const QFontInfo &,
 						  int x, int y, bool child_mark,

--- a/src/preferences_gui.ui
+++ b/src/preferences_gui.ui
@@ -2555,7 +2555,12 @@ If the picture is not set, or unvalid, a default goban is used by qgo</string>
             </item>
             <item>
              <property name="text">
-              <string>Score</string>
+              <string>Score difference</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Absolute score</string>
              </property>
             </item>
            </widget>


### PR DESCRIPTION
Formerly, the UI offered to show variations as win rate, win rate
difference, and absolute score. Add the option to show variations as
score difference.

This is particularly helpful for analyzing amateur games where the
winrate as computed by katago assumes perfect play which is unrealistic.
The score difference gives more information on how well amateur players
are doing with each stone.

Additionally, when variations are shown as absolute score or score
difference, use a color scheme based on the score difference rather than
based on the winrate difference. It is confusing when colors do not
match the numbers.