### PR TITLE
always return an analysis for the next move

### DIFF
--- a/src/board.cpp
+++ b/src/board.cpp
@@ -1019,6 +1019,8 @@ game_state *Board::analysis_at (int x, int y, int &num, double &primary_wr, doub
 			num++;
 		}
 	}
+	game_state *next = eval_root->next_move ();
+	if (next->get_move_x () == x && next->get_move_y () == y) return next;
 	return nullptr;
 }
 


### PR DESCRIPTION
This way, even if the next move had not been considered by kata-analyze,
we can display a winrate/score estimation based on the analysis of the
next board position. This allows the user to see at a glance, through
render_analysis_marks (), how bad the move they actually played was.